### PR TITLE
Update main.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,7 +35,7 @@
         - name: Install epel repository
           tags: ['epel']
           import_role:
-            name: apigee_opdk_setup_os_epel
+            name: apigee-opdk-setup-os-epel
 
         - name: Install pip, after installing epel repository
           yum:


### PR DESCRIPTION
Hi,
I have a bug with the main task
it should refer to apigee-opdk-setup-os-epel instead of apigee_opdk_setup_os_epel, no ?

When I launch my playbook
First I install 

```
- extracting apigee-opdk-setup-os-epel to /home/ampadmin/.ansible/roles/apigee-opdk-setup-os-epel
- apigee-opdk-setup-os-epel was installed successfully

```
then when pip is installed i have

```
The error appears to be in '/home/ampadmin/.ansible/roles/apigee-opdk-setup-os-pip/tasks/main.yml': line 38, column 19, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

          import_role:
            name: apigee_opdk_setup_os_epel
                  ^ here
```